### PR TITLE
fix: Adiciona dependência 'formidable' ausente

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "csv-writer": "^1.6.0",
     "express": "^4.18.2",
     "firebase-admin": "^11.5.0",
+    "formidable": "^3.5.1",
     "pdfkit": "0.13.0",
     "pdfkit-table": "0.1.99",
     "point-in-polygon": "^1.1.0",


### PR DESCRIPTION
Corrige uma falha no servidor causada pela ausência do módulo 'formidable'.

O servidor estava encerrando com um erro 'MODULE_NOT_FOUND' porque a dependência 'formidable', que é usada para processar uploads de arquivos, não estava declarada no arquivo `backend/package.json`.

Esta alteração adiciona 'formidable' à lista de dependências, resolvendo o erro de tempo de execução.