### PR TITLE
fix: Revert API key placeholders to fix login

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,11 +8,8 @@ import { openDB } from 'https://unpkg.com/idb@7.1.1/build/index.js';
 
 document.addEventListener('DOMContentLoaded', () => {
 
-    // As chaves de API e configurações do Firebase devem ser guardadas em variáveis de ambiente
-    // e injetadas no momento do build, ou carregadas de um endpoint seguro.
-    // NÃO DEVEM ser guardadas diretamente no código em produção.
     const firebaseConfig = {
-        apiKey: "YOUR_FIREBASE_API_KEY", // SUBSTITUIR PELA CHAVE REAL
+        apiKey: "AIzaSyBFXgXKDIBo9JD9vuGik5VDYZFDb_tbCrY",
         authDomain: "agrovetor-v2.firebaseapp.com",
         projectId: "agrovetor-v2",
         storageBucket: "agrovetor-v2.firebasestorage.app",

--- a/index.html
+++ b/index.html
@@ -2162,8 +2162,7 @@
             console.log("Google Maps API loaded.");
         }
     </script>
-    <!-- A chave da API do Google Maps também deve ser gerida de forma segura e não hardcoded -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=YOUR_GOOGLE_MAPS_API_KEY&libraries=geometry&callback=initMap" async defer></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCkik1KL7JjdyYoaifjK4i1J1tmmaRPL7U&libraries=geometry&callback=initMap" async defer></script>
 
     <!-- Script principal da aplicação -->
     <script type="module" src="./app.js"></script>


### PR DESCRIPTION
This commit reverts the changes that replaced the Firebase and Google Maps API keys with placeholders.

The previous change, while done for security best practices, prevented the user from being able to log in and test the application. This commit restores the original, hardcoded keys to make the application runnable again at the user's request.

- Restored the Firebase API key in `app.js`.
- Restored the Google Maps API key in `index.html`.