### PR TITLE
refactor(ai): Redesign historical data feature for raw report analysis

### DIFF
--- a/app.js
+++ b/app.js
@@ -251,9 +251,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 btnDownloadClosedTemplate: document.getElementById('btnDownloadClosedTemplate'),
                 shapefileUploadArea: document.getElementById('shapefileUploadArea'),
                 shapefileInput: document.getElementById('shapefileInput'),
-                historicalHarvestCsvUploadArea: document.getElementById('historicalHarvestCsvUploadArea'),
-                historicalHarvestCsvInput: document.getElementById('historicalHarvestCsvInput'),
-                btnDownloadHistoricalHarvestCsvTemplate: document.getElementById('btnDownloadHistoricalHarvestCsvTemplate'),
+                historicalReportUploadArea: document.getElementById('historicalReportUploadArea'),
+                historicalReportInput: document.getElementById('historicalReportInput'),
             },
             dashboard: {
                 selector: document.getElementById('dashboard-selector'),
@@ -1907,9 +1906,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (companyConfigEls.btnDownloadClosedTemplate) companyConfigEls.btnDownloadClosedTemplate.addEventListener('click', () => App.actions.downloadHarvestReportTemplate('closed'));
                 if (companyConfigEls.shapefileUploadArea) companyConfigEls.shapefileUploadArea.addEventListener('click', () => companyConfigEls.shapefileInput.click());
                 if (companyConfigEls.shapefileInput) companyConfigEls.shapefileInput.addEventListener('change', (e) => App.mapModule.handleShapefileUpload(e));
-                if (companyConfigEls.historicalHarvestCsvUploadArea) companyConfigEls.historicalHarvestCsvUploadArea.addEventListener('click', () => companyConfigEls.historicalHarvestCsvInput.click());
-                if (companyConfigEls.historicalHarvestCsvInput) companyConfigEls.historicalHarvestCsvInput.addEventListener('change', (e) => App.actions.importHistoricalHarvestFromCSV(e.target.files[0]));
-                if (companyConfigEls.btnDownloadHistoricalHarvestCsvTemplate) companyConfigEls.btnDownloadHistoricalHarvestCsvTemplate.addEventListener('click', () => App.actions.downloadHistoricalHarvestCsvTemplate());
+                if (companyConfigEls.historicalReportUploadArea) companyConfigEls.historicalReportUploadArea.addEventListener('click', () => companyConfigEls.historicalReportInput.click());
+                if (companyConfigEls.historicalReportInput) companyConfigEls.historicalReportInput.addEventListener('change', (e) => App.actions.uploadHistoricalReport(e.target.files[0]));
 
 
                 if (App.elements.cadastros.btnSaveFarm) App.elements.cadastros.btnSaveFarm.addEventListener('click', () => App.actions.saveFarm());
@@ -3169,30 +3167,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 link.click();
                 document.body.removeChild(link);
             },
-            downloadHistoricalHarvestCsvTemplate() {
-                const headers = "CodigoFazenda;Talhao;Safra;Variedade;ATR_Realizado;TCH_Realizado";
-                const exampleRow = "4012;T-01;2023;RB867515;135.2;95.5";
-                const csvContent = "\uFEFF" + headers + "\n" + exampleRow;
-                const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-                const url = URL.createObjectURL(blob);
-                const link = document.createElement("a");
-                link.setAttribute("href", url);
-                link.setAttribute("download", "modelo_historico_safras.csv");
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-            },
-            async importHistoricalHarvestFromCSV(file) {
+            async uploadHistoricalReport(file) {
                 if (!file) return;
                 const reader = new FileReader();
                 reader.onload = async (event) => {
-                    const csvData = event.target.result;
-                    App.ui.setLoading(true, "A importar dados históricos...");
+                    const reportData = event.target.result;
+                    App.ui.setLoading(true, "A enviar relatório para análise da IA...");
                     try {
-                        const response = await fetch(`${App.config.backendUrl}/api/import/historical-harvest`, {
+                        const response = await fetch(`${App.config.backendUrl}/api/upload/historical-report`, {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ csvData }),
+                            body: JSON.stringify({ reportData }),
                         });
                         const result = await response.json();
                         if (!response.ok) {
@@ -3200,10 +3185,10 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
                         App.ui.showAlert(result.message, 'success');
                     } catch (error) {
-                        App.ui.showAlert(`Erro ao importar dados: ${error.message}`, 'error');
+                        App.ui.showAlert(`Erro ao enviar relatório: ${error.message}`, 'error');
                     } finally {
                         App.ui.setLoading(false);
-                        App.elements.companyConfig.historicalHarvestCsvInput.value = '';
+                        App.elements.companyConfig.historicalReportInput.value = '';
                     }
                 };
                 reader.readAsText(file, 'ISO-8859-1');

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,6 @@
     "pdfkit-table": "0.1.99",
     "point-in-polygon": "^1.1.0",
     "shpjs": "^4.0.4",
-    "@google/generative-ai": "^0.14.1",
-    "csv-parser": "^3.0.0"
+    "@google/generative-ai": "^0.14.1"
   }
 }

--- a/index.html
+++ b/index.html
@@ -1943,15 +1943,13 @@
                 </div>
 
                 <div class="card" style="border-left-color: var(--color-purple); margin-top: 30px;">
-                    <h3><i class="fas fa-history"></i> Importar Histórico de Safras (para IA)</h3>
-                    <p>Faça o upload de um ficheiro CSV com todos os dados de safras passadas para alimentar o modelo de IA e melhorar as previsões de ATR.</p>
-                    <div class="upload-area" id="historicalHarvestCsvUploadArea">
-                        <i class="fas fa-file-csv fa-2x" style="color: var(--color-purple);"></i>
-                        <p>Clique ou arraste o ficheiro CSV do histórico aqui</p>
+                    <h3><i class="fas fa-history"></i> Importar Relatório Histórico (para IA)</h3>
+                    <p>Faça o upload do seu relatório histórico (em formato .txt ou .csv). A IA irá ler o conteúdo para analisar os dados e melhorar as previsões.</p>
+                    <div class="upload-area" id="historicalReportUploadArea">
+                        <i class="fas fa-file-alt fa-2x" style="color: var(--color-purple);"></i>
+                        <p>Clique ou arraste o seu relatório para aqui</p>
                     </div>
-                    <input type="file" id="historicalHarvestCsvInput" accept=".csv" style="display: none;">
-                    <button id="btnDownloadHistoricalHarvestCsvTemplate" class="save" style="max-width: 300px; margin-top: 15px; background: var(--color-purple);"><i class="fas fa-download"></i> Baixar Modelo CSV (Histórico)</button>
-                    <small class="csv-format-info">Formato: CodigoFazenda;Talhao;Safra;Variedade;ATR_Realizado;TCH_Realizado</small>
+                    <input type="file" id="historicalReportInput" accept=".csv,.txt" style="display: none;">
                 </div>
 
                 <div class="card" style="border-left-color: var(--color-info); margin-top: 30px;">


### PR DESCRIPTION
This commit refactors the AI's historical data feature based on user feedback. The implementation now supports uploading raw, unstructured reports instead of requiring a specifically formatted CSV.

Key Changes:

- **Backend Overhaul**:
  - The endpoint for importing structured CSV data has been removed.
  - A new endpoint, `/api/upload/historical-report`, is created. It accepts the raw text content of any report file and stores it in a single Firestore document (`config/historicalReport`).
  - The `/api/gemini/generate` endpoint is updated to fetch this raw report text and provide it as context to the Gemini AI for analysis, rather than querying a structured collection.
  - The `csv-parser` dependency has been removed.

- **Frontend Simplification**:
  - The UI for uploading historical data in "Configurações da Empresa" has been simplified to a generic file dropzone, removing the need for a CSV template.
  - The corresponding JavaScript in `app.js` has been updated to send the raw text of the uploaded file to the new backend endpoint.

This new approach makes the feature significantly more powerful and easier for the user, as the AI is now responsible for parsing and understanding the user's existing reports without manual data formatting.