### PR TITLE
fix: Correct file upload functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -1915,8 +1915,33 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (companyConfigEls.btnDownloadClosedTemplate) companyConfigEls.btnDownloadClosedTemplate.addEventListener('click', () => App.actions.downloadHarvestReportTemplate('closed'));
                 if (companyConfigEls.shapefileUploadArea) companyConfigEls.shapefileUploadArea.addEventListener('click', () => companyConfigEls.shapefileInput.click());
                 if (companyConfigEls.shapefileInput) companyConfigEls.shapefileInput.addEventListener('change', (e) => App.mapModule.handleShapefileUpload(e));
-                if (companyConfigEls.historicalReportUploadArea) companyConfigEls.historicalReportUploadArea.addEventListener('click', () => companyConfigEls.historicalReportInput.click());
-                if (companyConfigEls.historicalReportInput) companyConfigEls.historicalReportInput.addEventListener('change', (e) => App.actions.uploadHistoricalReport(e.target.files[0]));
+
+                // Event listeners for historical report upload
+                if (companyConfigEls.historicalReportUploadArea) {
+                    const uploadArea = companyConfigEls.historicalReportUploadArea;
+                    const input = companyConfigEls.historicalReportInput;
+
+                    uploadArea.addEventListener('click', () => input.click());
+                    input.addEventListener('change', (e) => App.actions.uploadHistoricalReport(e.target.files[0]));
+
+                    uploadArea.addEventListener('dragover', (e) => {
+                        e.preventDefault();
+                        uploadArea.classList.add('dragover');
+                    });
+
+                    uploadArea.addEventListener('dragleave', () => {
+                        uploadArea.classList.remove('dragover');
+                    });
+
+                    uploadArea.addEventListener('drop', (e) => {
+                        e.preventDefault();
+                        uploadArea.classList.remove('dragover');
+                        if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                            App.actions.uploadHistoricalReport(e.dataTransfer.files[0]);
+                            input.files = e.dataTransfer.files; // Optional: syncs the file list
+                        }
+                    });
+                }
 
 
                 if (App.elements.cadastros.btnSaveFarm) App.elements.cadastros.btnSaveFarm.addEventListener('click', () => App.actions.saveFarm());

--- a/index.html
+++ b/index.html
@@ -1941,6 +1941,12 @@
                         <i class="fas fa-file-alt fa-2x" style="color: var(--color-purple);"></i>
                         <p>Clique ou arraste o seu relatório para aqui</p>
                     </div>
+                <style>
+                    .upload-area.dragover {
+                        border-color: var(--color-purple);
+                        background-color: var(--color-primary-light);
+                    }
+                </style>
                     <input type="file" id="historicalReportInput" accept=".csv,.txt" style="display: none;">
                 </div>
 


### PR DESCRIPTION
This commit fixes a bug in the historical report upload feature where clicking the upload area did not open the file dialog and dragging a file onto it caused the browser to download the file instead of uploading it.

- The `click` event listener is now correctly wired to the hidden file input.
- `dragover` and `drop` event listeners have been added to the upload area.
- The `preventDefault()` method is used on these events to stop the browser's default behavior of opening/downloading the file.
- The `drop` event handler now correctly extracts the file and passes it to the upload action.
- A CSS class is added during `dragover` to provide visual feedback to the user.