### PR TITLE
fix: Correct historical report upload endpoint URL

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -89,7 +89,7 @@ try {
     });
 
     // ROTA PARA INGESTÃO INTELIGENTE DE RELATÓRIO HISTÓRICO
-    app.post('/api/import/historical-report', async (req, res) => {
+    app.post('/api/upload/historical-report', async (req, res) => {
         const { reportData } = req.body;
         if (!reportData) {
             return res.status(400).json({ message: 'Nenhum dado de relatório foi enviado.' });


### PR DESCRIPTION
This commit fixes a 404 Not Found error that occurred when trying to upload a historical report.

The error was caused by a mismatch between the endpoint URL called by the frontend and the one defined on the backend.

- The backend route in `server.js` has been renamed from `/api/import/historical-report` to `/api/upload/historical-report` to match the frontend implementation.