### PR TITLE
fix: Make AI report ingestion more robust

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -116,7 +116,19 @@ try {
             const mappingResult = await model.generateContent(mappingPrompt);
             const mappingResponse = await mappingResult.response;
             let mappingText = mappingResponse.text().replace(/```json/g, '').replace(/```/g, '').trim();
-            const columnMapping = JSON.parse(mappingText);
+
+            let columnMapping;
+            try {
+                columnMapping = JSON.parse(mappingText);
+            } catch (e) {
+                console.error("Erro: A IA retornou um JSON inválido para o mapeamento de colunas.", mappingText);
+                return res.status(500).json({ message: "A IA não conseguiu entender a estrutura das colunas do seu relatório. Verifique se o arquivo é um CSV válido com cabeçalhos." });
+            }
+
+            if (!columnMapping || Object.keys(columnMapping).length === 0) {
+                console.error("Erro: O mapeamento de colunas da IA está vazio ou inválido.", columnMapping);
+                return res.status(500).json({ message: "A IA não conseguiu identificar colunas válidas no seu relatório." });
+            }
 
             // 3. Processa o CSV completo com o mapeamento da IA
             const records = [];


### PR DESCRIPTION
This commit adds significant error handling and validation to the historical report ingestion pipeline to prevent the server from crashing due to unexpected or malformed AI responses.

- The endpoint `/api/upload/historical-report` now includes a `try...catch` block specifically for parsing the JSON response from the Gemini AI's column mapping task.
- If the AI returns invalid JSON, the server no longer crashes. Instead, it logs the problematic response for debugging and returns a user-friendly 500 error.
- An additional check ensures that the generated column map is a valid, non-empty object before proceeding with parsing the full report.

These changes make the feature more resilient and provide better diagnostics for cases where the AI has difficulty understanding a specific report format.