### PR TITLE
feat: Add historical data management and improve ATR prediction UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1941,19 +1941,14 @@
                 </div>
 
                 <div class="card" style="border-left-color: var(--color-purple); margin-top: 30px;">
-                    <h3><i class="fas fa-history"></i> Importar Relatório Histórico (para IA)</h3>
-                    <p>Faça o upload do seu relatório histórico (em formato .txt ou .csv). A IA irá ler o conteúdo para analisar os dados e melhorar as previsões.</p>
+                    <h3><i class="fas fa-history"></i> Gerir Histórico de Dados da IA</h3>
+                    <p>Faça o upload de relatórios (.csv, .txt, .xlsx) para treinar a IA. Você também pode apagar todos os dados históricos para começar do zero.</p>
                     <div class="upload-area" id="historicalReportUploadArea">
                         <i class="fas fa-file-alt fa-2x" style="color: var(--color-purple);"></i>
                         <p>Clique ou arraste o seu relatório para aqui</p>
                     </div>
-                <style>
-                    .upload-area.dragover {
-                        border-color: var(--color-purple);
-                        background-color: var(--color-primary-light);
-                    }
-                </style>
-                    <input type="file" id="historicalReportInput" accept=".csv,.txt" style="display: none;">
+                    <input type="file" id="historicalReportInput" accept=".csv,.txt,.xlsx" style="display: none;">
+                    <button id="btnDeleteHistoricalData" class="btn-excluir" style="width: 100%; max-width: 300px; margin-top: 15px; justify-content: center;"><i class="fas fa-trash"></i> Apagar Todo o Histórico</button>
                 </div>
 
                 <div class="card" style="border-left-color: var(--color-info); margin-top: 30px;">


### PR DESCRIPTION
This commit introduces a new feature for managing the AI's historical data and improves the user experience of the ATR prediction in the harvest planning module.

Key Features & Enhancements:

- **Delete Historical Data:**
  - A "Delete All Historical Data" button has been added to the settings page.
  - A new backend endpoint (`/api/delete/historical-data`) handles the secure deletion of all documents in the `historicalHarvests` collection using batch processing.
  - The frontend includes a confirmation modal requiring the user to type "EXCLUIR HISTORICO" to prevent accidental data loss.

- **Non-Blocking ATR Prediction UI:**
  - The "ATR Previsto" input field is now `readonly` to prevent manual edits.
  - The global loading screen during ATR prediction has been replaced with a non-blocking local spinner next to the input field.
  - The automatic prediction is now correctly triggered by the "Select All" checkbox in addition to individual checkbox clicks.