### PR TITLE
feat: Replace AI-based ATR prediction with direct calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1496,7 +1496,7 @@
                             <div class="form-col">
                                 <label for="harvestAtr" class="required">ATR Previsto:</label>
                                 <div style="display: flex; align-items: center;">
-                                    <input type="number" id="harvestAtr" placeholder="Selecione talhões..." readonly>
+                                    <input type="number" id="harvestAtr" placeholder="ATR Previsto">
                                     <i id="atr-spinner" class="fas fa-spinner fa-spin" style="display: none; margin-left: 10px; color: var(--color-primary);"></i>
                                 </div>
                             </div>


### PR DESCRIPTION
Refactors the ATR prediction functionality to improve reliability and accuracy.

- Replaces the AI-based ATR prediction with a deterministic, non-AI endpoint (`/api/calculate-atr`) on the backend.
- The new endpoint calculates the predicted ATR using a weighted average based on historical harvest data (`SUM(ATR * Tonelada) / SUM(Tonelada)`), as specified by the user.
- Updates the frontend `app.js` to call this new endpoint.
- Improves the user experience by making the ATR input field `readonly` only during the fetch operation and ensuring the loading spinner is displayed and hidden correctly.
- Corrects the text on the optimization button from "Otimizar Sequência" to "Otimizar Colheita" for clarity.
- Fixes a bug in `index.html` where the ATR input field was permanently `readonly`, preventing manual entry.