### PR TITLE
fix: Harmonize codigoFazenda data type for ATR calculation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -218,7 +218,7 @@ try {
                             }
                             // Limpa e formata os dados
                             const finalRecord = {
-                                codigoFazenda: record.codigoFazenda || null,
+                                codigoFazenda: String(record.codigoFazenda || '').trim(),
                                 talhao: record.talhao || null,
                                 safra: record.safra || null,
                                 variedade: record.variedade || null,
@@ -275,8 +275,9 @@ try {
         }
 
         try {
+            const farmCodeStr = String(codigoFazenda || '').trim();
             const historyQuery = await db.collection('historicalHarvests')
-                .where('codigoFazenda', '==', codigoFazenda)
+                .where('codigoFazenda', '==', farmCodeStr)
                 .get();
 
             if (historyQuery.empty) {


### PR DESCRIPTION
This commit fixes a bug where the ATR (Azúcares Totais Recuperáveis) calculation was failing because of a data type mismatch for the `codigoFazenda` field in the `historicalHarvests` collection.

- In the `/api/upload/historical-report` endpoint, the `codigoFazenda` is now explicitly cast to a string before being saved to Firestore. This prevents the CSV parser from auto-inferring it as a number.
- In the `/api/calculate-atr` endpoint, the `codigoFazenda` received from the client is also cast to a string before being used in the Firestore `where` clause.

This ensures that the query for historical data will correctly match documents, resolving the issue where the calculation was not being performed despite the presence of historical data.