### PR TITLE
feat: Add date range selection for employee history

### DIFF
--- a/index.html
+++ b/index.html
@@ -2040,8 +2040,16 @@
                         <div style="padding: 15px 20px;">
                             <label for="historyUserSelect" class="required">Colaborador:</label>
                             <select id="historyUserSelect"></select>
-                            <label for="historyDateInput" class="required">Data:</label>
-                            <input type="date" id="historyDateInput">
+                            <div class="form-row" style="gap: 10px; margin-bottom: 0;">
+                                <div class="form-col">
+                                    <label for="historyStartDateInput" class="required" style="font-size: 13px;">Data Início:</label>
+                                    <input type="date" id="historyStartDateInput">
+                                </div>
+                                <div class="form-col">
+                                    <label for="historyEndDateInput" class="required" style="font-size: 13px;">Data Fim:</label>
+                                    <input type="date" id="historyEndDateInput">
+                                </div>
+                            </div>
                             <button id="btnViewHistory" class="save" style="width: 100%; margin-top: 15px; background: var(--color-purple);">
                                 <i class="fas fa-search-location"></i> Ver Trajeto
                             </button>


### PR DESCRIPTION
This commit enhances the employee tracking feature by allowing administrators to select a date range (start and end date) to view an employee's historical path, rather than just a single day.

- **UI (`index.html`):** The single date input in the history controls has been replaced with two date inputs for start and end dates.
- **Logic (`app.js`):**
    - The `fetchAndDrawHistory` function has been updated to query the `user_location_history` collection for all documents within the selected date range for a specific user.
    - It now combines the `path_points` from all fetched documents and sorts them chronologically to draw a single, continuous path on the map.
    - The element references and default date settings have been updated to support the new UI.