### PR TITLE
fix: Correct tracking UI state and update defaults

### DIFF
--- a/app.js
+++ b/app.js
@@ -631,6 +631,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 clearTimeout(App.state.inactivityTimer);
                 clearTimeout(App.state.inactivityWarningTimer);
                 localStorage.removeItem('agrovetor_lastActiveTab');
+
+                // Garante que a UI de admin seja limpa ao sair
+                const historyControls = App.elements.monitoramentoAereo.historyControls;
+                const showHistoryBtn = App.elements.monitoramentoAereo.btnShowHistoryPanel;
+                if (historyControls) historyControls.style.display = 'none';
+                if (showHistoryBtn) showHistoryBtn.style.display = 'none';
+
                 App.ui.showLoginScreen();
             },
             initiateUserCreation() {
@@ -875,6 +882,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 App.ui.setLoading(false);
             },
             showAppScreen() {
+                // Garante que a UI de admin seja reiniciada antes de mostrar a tela
+                const historyControls = App.elements.monitoramentoAereo.historyControls;
+                const showHistoryBtn = App.elements.monitoramentoAereo.btnShowHistoryPanel;
+                if (historyControls) historyControls.style.display = 'none';
+                if (showHistoryBtn) showHistoryBtn.style.display = 'none';
+
                 const { currentUser } = App.state;
                 App.ui.setLoading(false);
                 App.elements.loginScreen.style.display = 'none';
@@ -4715,11 +4728,11 @@ document.addEventListener('DOMContentLoaded', () => {
             },
 
             initializeAdminView() {
-                // Mostra os controlos de histórico e preenche os dados
+                // Configura os controlos de histórico para estarem fechados por padrão
                 const historyControls = App.elements.monitoramentoAereo.historyControls;
-                if (historyControls) {
-                    historyControls.style.display = 'block';
-                }
+                const showHistoryBtn = App.elements.monitoramentoAereo.btnShowHistoryPanel;
+                if (historyControls) historyControls.style.display = 'none';
+                if (showHistoryBtn) showHistoryBtn.style.display = 'flex';
 
                 const userSelect = App.elements.monitoramentoAereo.historyUserSelect;
                 if (userSelect) {


### PR DESCRIPTION
This commit addresses user feedback on the employee tracking feature, including a critical bug fix and a UI/UX improvement.

1.  **Bug Fix: Persistent Admin UI**
    - The admin-only 'Path History' panel and its controls no longer persist on the screen after an admin logs out and a non-admin user logs in.
    - Logic has been added to the `logout` and `showAppScreen` functions to explicitly hide admin-specific UI elements, ensuring a clean state between user sessions without requiring a page refresh.

2.  **UI Improvement: History Panel Closed by Default**
    - The 'Path History' panel on the map screen now loads in a closed state by default for administrators.
    - The 'Show Panel' button is displayed instead, allowing the admin to open the controls when needed. This provides a cleaner initial map view.