### PR TITLE
feat: Replace Google Maps with Mapbox GL JS

### DIFF
--- a/index.html
+++ b/index.html
@@ -2210,14 +2210,11 @@
     <script src="https://unpkg.com/shpjs@latest/dist/shp.js"></script>
     <script src="https://unpkg.com/idb@7.1.1/build/index.js"></script>
     
-    <script>
-        function initMap() {
-            // Esta função será chamada pela API do Google Maps quando estiver pronta.
-            // O App.js irá redefinir esta função para iniciar o mapa de fato.
-            console.log("Google Maps API loaded.");
-        }
-    </script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCkik1KL7JjdyYoaifjK4i1J1tmmaRPL7U&libraries=geometry&callback=initMap" async defer></script>
+    <!-- Mapbox GL JS -->
+    <link href="https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.css" rel="stylesheet">
+    <script src="https://api.mapbox.com/mapbox-gl-js/v3.14.0/mapbox-gl.js"></script>
+    <!-- Turf.js for spatial analysis -->
+    <script src="https://cdn.jsdelivr.net/npm/@turf/turf@7/turf.min.js"></script>
 
     <!-- Script principal da aplicação -->
     <script type="module" src="./app.js"></script>


### PR DESCRIPTION
This commit migrates the mapping functionality from Google Maps to Mapbox GL JS.

Key changes:
- Replaced the Google Maps API script in `index.html` with the Mapbox GL JS and Turf.js CDN links.
- Refactored the `mapModule` in `app.js` to use the Mapbox GL JS API.
- Updated the application state to manage Mapbox objects instead of Google Maps objects.
- Replaced `google.maps.Marker` with `mapboxgl.Marker` for user location and trap markers, using custom DOM elements for styling.
- Replaced the `google.maps.Data` layer with Mapbox sources and layers for displaying GeoJSON polygons, including hover and click interactions.
- Replaced `google.maps.geometry.poly.containsLocation` with `turf.booleanPointInPolygon` for accurate point-in-polygon checks.