### PR TITLE
fix: Replace Google Maps with Mapbox and correct token usage

### DIFF
--- a/app.js
+++ b/app.js
@@ -3811,7 +3811,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
 
                 try {
-                    mapboxgl.accessToken = 'sk.eyJ1IjoiY2FybG9zaGduIiwiYSI6ImNtZjFjeGtpbzJldzEya3B5ZHhwc2ZpdmIifQ.VhLX-V4mwXQnpbMk7LVJqA';
+                    mapboxgl.accessToken = 'pk.eyJ1IjoiY2FybG9zaGduIiwiYSI6ImNtZDk0bXVxeTA0MTcyam9sb2h1dDhxaG8ifQ.uf0av4a0WQ9sxM1RcFYT2w';
                     const mapContainer = App.elements.monitoramentoAereo.mapContainer;
 
                     App.state.mapboxMap = new mapboxgl.Map({


### PR DESCRIPTION
This commit migrates the mapping functionality from Google Maps to Mapbox GL JS and fixes the initial implementation which used an incorrect secret token.

Key changes:
- Replaced the Google Maps API script in `index.html` with the Mapbox GL JS and Turf.js CDN links.
- Refactored the `mapModule` in `app.js` to use the Mapbox GL JS API.
- Corrected the Mapbox access token to use the public token (`pk.*`) required for client-side rendering.
- Updated the application state to manage Mapbox objects.
- Replaced `google.maps.Marker` with `mapboxgl.Marker` for user location and trap markers.
- Replaced the `google.maps.Data` layer with Mapbox sources and layers for GeoJSON polygons.
- Replaced `google.maps.geometry.poly.containsLocation` with `turf.booleanPointInPolygon` for spatial analysis.