### PR TITLE
feat: Implement employee location tracking feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -2019,6 +2019,27 @@
                 </div>
 
             </section>
+
+            <section id="rastreioHistorico" class="tab-content card" aria-label="Histórico de Rastreio" tabindex="0" hidden>
+                <h2><i class="fas fa-map-marked-alt"></i> Histórico de Rastreio</h2>
+                <p>Selecione um utilizador e um intervalo de datas para visualizar o percurso no mapa.</p>
+                <div class="form-row">
+                    <div class="form-col">
+                        <label for="historyUserSelect" class="required">Utilizador:</label>
+                        <select id="historyUserSelect" required></select>
+                    </div>
+                    <div class="form-col">
+                        <label for="historyStartDate" class="required">Data Início:</label>
+                        <input type="date" id="historyStartDate" required />
+                    </div>
+                    <div class="form-col">
+                        <label for="historyEndDate" class="required">Data Fim:</label>
+                        <input type="date" id="historyEndDate" required />
+                    </div>
+                </div>
+                <button class="save" id="btnViewHistory" style="max-width: 300px;"><i class="fas fa-eye"></i> Visualizar Percurso</button>
+                <div id="historyMapContainer" style="height: 600px; width: 100%; margin-top: 20px; border-radius: var(--border-radius); border: 1px solid var(--color-border);"></div>
+            </section>
         </main>
         
         <div id="monitoramentoAereo-container" class="tab-content">


### PR DESCRIPTION
This commit introduces a new feature for administrators to view the location history of users.

Backend (`backend/server.js`):
- Adds a new Firestore collection `locationHistory` to store location data.
- Creates a POST endpoint `/api/track` to receive and save location updates from the client.
- Creates a GET endpoint `/api/history` that allows admins to fetch location data for a specific user within a date range.

Frontend (`app.js`, `index.html`):
- Implements real-time location tracking on the client-side using `navigator.geolocation.watchPosition`.
- Periodically sends location updates to the `/api/track` endpoint.
- Adds a new 'Histórico de Rastreio' view, accessible only to administrators.
- The new view contains a separate Mapbox map, a user selector, and date filters.
- Implements the logic to fetch data from the `/api/history` endpoint and render the user's path on the map using a line layer and markers for start/end points.