### PR TITLE
fix: Correct JavaScript errors causing infinite load

### DIFF
--- a/app.js
+++ b/app.js
@@ -1211,7 +1211,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
             },
             populateUserSelects() {
-                const selects = [App.elements.planejamento.responsavel, App.elements.history.userSelect];
+                const selects = [App.elements.planejamento.responsavel, App.elements.historyFilterModal.userSelect];
                 selects.forEach(select => {
                     if (!select) return;
                     const currentValue = select.value;
@@ -2230,7 +2230,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
 
                 window.addEventListener('online', () => App.actions.syncOfflineWrites());
-                if (App.elements.history.btnView) App.elements.history.btnView.addEventListener('click', () => App.actions.viewHistory());
 
                 const historyModal = App.elements.historyFilterModal;
                 if (historyModal.overlay) historyModal.overlay.addEventListener('click', e => { if(e.target === historyModal.overlay) this.hideHistoryFilterModal(); });


### PR DESCRIPTION
This commit fixes two critical reference errors introduced in the previous feature implementation:

1.  In `populateUserSelects`, a reference to a deleted elements object (`App.elements.history.userSelect`) was still present. This has been updated to point to the new modal's select element (`App.elements.historyFilterModal.userSelect`).
2.  In `setupEventListeners`, an event listener was being attached to a button (`App.elements.history.btnView`) that no longer exists. This line has been removed.

These errors were causing the script to fail during initialization, preventing the application from loading.