### PR TITLE
feat: Implement Censo Varietal 'By Cut' model and fix map bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1945,6 +1945,13 @@
                             <option value="">Todas</option>
                         </select>
                     </div>
+                    <div class="form-col">
+                        <label for="censoVarietalModel">Modelo do Relatório:</label>
+                        <select id="censoVarietalModel">
+                            <option value="variety">Por Variedade</option>
+                            <option value="cut">Por Corte</option>
+                        </select>
+                    </div>
                 </div>
                 <div class="checkbox-group-container">
                     <label>Filtrar por Tipo de Fazenda (deixar em branco para todas):</label>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'agrovetor-cache-v7'; // Incremented version
+const CACHE_NAME = 'agrovetor-cache-v8'; // Incremented version
 const TILE_CACHE_NAME = 'agrovetor-tile-cache-v1';
 const MAX_TILES_IN_CACHE = 2000; // Max number of tiles to cache
 
@@ -79,9 +79,8 @@ self.addEventListener('fetch', event => {
 
   const url = new URL(event.request.url);
 
-  // Strategy for Google Maps satellite TILEs (Cache First with trimming)
-  // The path '/kh/v=' is specific to satellite imagery (Keyhole).
-  if (url.hostname.endsWith('.google.com') && url.pathname.includes('/kh/v=')) {
+  // Strategy for Mapbox tiles (Cache First with trimming)
+  if (url.hostname.endsWith('api.mapbox.com')) {
     event.respondWith(
       caches.open(TILE_CACHE_NAME).then(cache => {
         return cache.match(event.request).then(response => {


### PR DESCRIPTION
This commit introduces several new features and bug fixes:

1.  **Censo Varietal Report Enhancement**:
    *   Adds a new "Por Corte" (By Cut) model to the Censo Varietal report.
    *   Users can now select between the original "Por Variedade" model and the new "Por Corte" model via a dropdown in the UI.
    *   The backend endpoint `/reports/censo-varietal/:format` has been updated to handle both models, aggregating data by variety or by cut age accordingly and generating the correct PDF/CSV.

2.  **Map Module Bug Fixes**:
    *   Resolves a critical bug in the trap installation modal where legacy Google Maps code was still being used after the migration to Mapbox, preventing confirmation of new traps. The logic now correctly uses Mapbox objects and methods.
    *   Updates the `service-worker.js` to correctly cache Mapbox map tiles for offline use, replacing the obsolete Google Maps tile caching logic. Incremented cache version to `v8` to ensure the new service worker is activated.

3.  **Code Review and Refinements**:
    *   Completed a comprehensive review of all new and modified code.
    *   Ensured all new features are correctly integrated into the existing application structure.