### PR TITLE
feat: Fix reports and implement editable Cutting Orders

### DIFF
--- a/index.html
+++ b/index.html
@@ -1797,7 +1797,6 @@
                             <select id="tipoRelatorioColheita">
                                 <option value="detalhado">Detalhado por Fazenda</option>
                                 <option value="mensal">Previsão Mensal</option>
-                                <option value="saldo">Saldo de Colheita</option>
                             </select>
                         </div>
                     </div>
@@ -1873,7 +1872,14 @@
                     </div>
                 </div>
                 <div class="checkbox-group-container">
-                    <label>Filtrar por Tipo de Fazenda (deixar em branco para todas):</label>
+                    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+                        <label>Filtrar por Tipo de Fazenda:</label>
+                        <label class="report-option-item" style="flex-direction: row; padding: 5px 10px; height: auto;">
+                            <input type="checkbox" id="censoVarietalSelectAll">
+                            <span class="checkbox-visual" style="position: static; width: 18px; height: 18px;"></span>
+                            <span class="option-content" style="font-size: 14px;">Selecionar Todos</span>
+                        </label>
+                    </div>
                     <div class="checkbox-group-grid" id="censoVarietalFarmTypeFilter">
                         <label class="report-option-item"><input type="checkbox" name="censoFarmType" value="Própria"><span class="checkbox-visual"><i class="fas fa-check"></i></span><span class="option-content">Própria</span></label>
                         <label class="report-option-item"><input type="checkbox" name="censoFarmType" value="Parceira"><span class="checkbox-visual"><i class="fas fa-check"></i></span><span class="option-content">Parceira</span></label>
@@ -2452,6 +2458,21 @@
                     <div class="modal-footer">
                         <button id="cuttingOrderModalCancelBtn" class="btn-secondary">Cancelar</button>
                         <button id="cuttingOrderModalConfirmBtn" class="save"><i class="fas fa-file-alt"></i> Confirmar e Gerar Ordem</button>
+                    </div>
+                </div>
+            </div>
+
+            <div id="viewCuttingOrderModal" class="modal-overlay">
+                <div class="modal-content" style="max-width: 800px;">
+                    <div class="modal-header">
+                        <h2 id="viewCuttingOrderModalTitle">Detalhes da Ordem de Corte</h2>
+                        <button id="viewCuttingOrderModalCloseBtn" class="modal-close-btn">&times;</button>
+                    </div>
+                    <div id="viewCuttingOrderModalBody">
+                        <!-- Content will be injected by JS -->
+                    </div>
+                    <div class="modal-footer">
+                        <button id="viewCuttingOrderModalOkBtn" class="save">OK</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This commit addresses several user-reported issues and feature requests.

- **Failing Reports:**
  - The 'Relatório de Plantio' endpoint in `server.js` has been enhanced to fetch associated farm data and include all relevant details, providing a comprehensive report.
  - The 'O que Falta Colher' report has been refactored to show plot-by-plot data with subtotals and a grand total.
  - A new PDF endpoint was created for the 'Previsão Mensal' report.
  - A frontend routing bug in `app.js` was fixed. The 'Custom Report' screen now correctly calls the appropriate backend endpoints.
  - The 'Censo Varietal' report now includes variety participation percentages in both PDF and CSV formats.

- **Editable Cutting Orders:**
  - The 'Ordem de Corte' module has been refactored from a static view into a full CRUD feature.
  - The UI now shows a compact list with a "View" button that opens a details modal.
  - Users can now edit and delete existing cutting orders.
  - The manual order creation modal is now reused for editing.

- **Bug Fixes:**
  - Corrected a `this` context issue in `app.js` that was causing a crash in the cutting order modal.
  - Moved a report generation function to the correct object to fix a `is not a function` error.