### PR TITLE
feat: Fix reports and redesign Cutting Order module

### DIFF
--- a/index.html
+++ b/index.html
@@ -1901,6 +1901,10 @@
                             <option value="cut">Por Corte</option>
                         </select>
                     </div>
+        <div class="form-col">
+            <label for="censoVarietalCuttingOrder">Filtrar por Ordem de Corte (Nº):</label>
+            <input type="number" id="censoVarietalCuttingOrder" placeholder="Digite o nº da OC">
+        </div>
                 </div>
                 <div class="checkbox-group-container">
                     <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">


### PR DESCRIPTION
This commit addresses multiple user requests to fix and enhance the application's reporting and UI.

- **Reports:**
  - Fixed layout issues in "Censo Varietal" and "O que falta colher" PDF reports by implementing dynamic and fixed column widths to prevent data overlap.
  - Fixed a bug in the "Censo Varietal" report where filters were not being consistently applied across different report models.
  - Fixed a bug that caused blank pages to be generated in some PDF reports.

- **Enhancements:**
  - The "Relatório por Cortes" (a model of the "Censo Varietal" report) has been enhanced with two new columns:
    1.  **Maturação:** Automatically classifies sugarcane varieties as 'Precoce', 'Média', or 'Tardia'.
    2.  **Participação (%):** Shows the percentage of each variety's area relative to the total.
  - Added a new filter to the "Censo Varietal" report to allow filtering by a manual Cutting Order number.

- **UI/UX:**
  - Redesigned the "Ordem de Corte" list view from a basic table to a modern, responsive, card-based layout. This improves usability, especially on mobile devices, and provides more information at a glance.