### PR TITLE
Fix: Correctly calculate average loss in `savePerda`

### DIFF
--- a/app.js
+++ b/app.js
@@ -3750,6 +3750,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 const fields = { canaInteira: parseFloat(perda.canaInteira.value) || 0, tolete: parseFloat(perda.tolete.value) || 0, toco: parseFloat(perda.toco.value) || 0, ponta: parseFloat(perda.ponta.value) || 0, estilhaco: parseFloat(perda.estilhaco.value) || 0, pedaco: parseFloat(perda.pedaco.value) || 0 };
                 const total = Object.values(fields).reduce((s, v) => s + v, 0);
+                const nonZeroFieldsCount = Object.values(fields).filter(v => v > 0).length;
+                const media = nonZeroFieldsCount > 0 ? total / nonZeroFieldsCount : 0;
                 const newEntry = {
                     ...fields,
                     data: perda.data.value,
@@ -3762,7 +3764,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     matricula: operator.matricula,
                     operador: operator.name,
                     total,
-                    media: (total / 6).toFixed(2).replace('.', ','),
+                    media: media.toFixed(2).replace('.', ','),
                     usuario: App.state.currentUser.username
                 };
 

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
The average loss (`media`) was previously calculated by dividing the total loss by a hardcoded value of 6. This was incorrect if the user did not provide a value for all six loss-type fields.

This commit fixes the calculation to divide the total loss by the number of loss-type fields that have a value greater than zero. This ensures the average is calculated correctly based on the provided inputs and prevents a division-by-zero error if no inputs are provided.

A `.gitignore` file was also added to the `backend` directory to allow for the installation of npm dependencies, which was a necessary step to attempt verification of the application.