### PR TITLE
Fix: Correct variable name in addPlotToPlantingPlan function

### DIFF
--- a/app.js
+++ b/app.js
@@ -4478,8 +4478,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
             addPlotToPlantingPlan() {
                 if (!App.state.activePlantingPlan) return;
-                const { plantingFazenda, talhaoSelectionList, plantingType, plantingDate } = App.elements.planting;
-                const farmId = plantingFazenda.value;
+                const { fazenda, talhaoSelectionList, plantingType, plantingDate } = App.elements.planting;
+                const farmId = fazenda.value;
                 const type = plantingType.value;
                 const date = plantingDate.value;
 


### PR DESCRIPTION
A TypeError was occurring in the `addPlotToPlantingPlan` function because it was attempting to destructure a property named `plantingFazenda` from `App.elements.planting`. The correct property name is `fazenda`.

This fatal JavaScript error was likely the root cause of other reported issues, such as the administrative menu becoming unresponsive, as it would halt script execution on the page.

This commit corrects the variable name in the destructuring, resolving the TypeError and restoring application stability.