### PR TITLE
Fix: Prevent crash when rendering menus with missing permissions

### DIFF
--- a/app.js
+++ b/app.js
@@ -987,9 +987,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 menu.appendChild(menuContent);
 
                 const createMenuItem = (item) => {
-                    const hasPermission = item.submenu ? 
-                                          item.submenu.some(sub => currentUser.permissions[sub.permission]) : 
-                                          currentUser.permissions[item.permission];
+                    const hasPermission = item.submenu ?
+                                          item.submenu.some(sub => (currentUser.permissions || {})[sub.permission]) :
+                                          (currentUser.permissions || {})[item.permission];
 
                     if (!hasPermission) return null;
                     
@@ -1031,7 +1031,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 submenuContent.appendChild(backBtn);
                 
                 parentItem.submenu.forEach(subItem => {
-                    if (App.state.currentUser.permissions[subItem.permission]) {
+                    if ((App.state.currentUser.permissions || {})[subItem.permission]) {
                         const subBtn = document.createElement('button');
                         subBtn.className = 'submenu-btn';
                         subBtn.innerHTML = `<i class="${subItem.icon}"></i> ${subItem.label}`;


### PR DESCRIPTION
This commit fixes a critical bug that caused the application to show a blank screen when a user clicked on an administrative sub-menu item.

The root cause was a `TypeError` that occurred when checking for user permissions if the `currentUser.permissions` object was `undefined`. This would happen if a user's document in Firestore was missing the permissions field.

The fix makes the permission-checking logic more robust by providing an empty object `{}` as a fallback. This ensures that the check gracefully fails instead of crashing the application. The change was applied to the permission checks for both main menu items and submenu items in the `renderMenu` and `renderSubmenu` functions.