### PR TITLE
fix(sync): Reiniciar ouvintes do Firestore na reconexão

### DIFF
--- a/app.js
+++ b/app.js
@@ -3731,6 +3731,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     console.log("A forçar a atualização do token de autenticação...");
                     await auth.currentUser.getIdToken(true);
                     console.log("Token de autenticação atualizado com sucesso.");
+
+                    // Reinicia os 'ouvintes' de dados para usar o novo token
+                    App.data.listenToAllData();
+
                     // Após a atualização bem-sucedida do token, iniciar a sincronização.
                     this.syncOfflineWrites();
                 } catch (error) {


### PR DESCRIPTION
Corrige um erro de 'Permissões insuficientes' que ocorria durante a sincronização de dados offline após a reconexão.

O problema era causado pelos 'ouvintes' do Firestore que não eram atualizados com o novo token de autenticação. A solução envolve chamar `listenToAllData()` após a atualização do token em `forceTokenRefresh`, garantindo que toda a comunicação com o banco de dados use a autenticação mais recente.