### PR TITLE
Fix: Broken offline map functionality and obsolete map logic.

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
-const CACHE_NAME = 'agrovetor-cache-v9'; // Incremented version
-const TILE_CACHE_NAME = 'agrovetor-tile-cache-v1';
+const CACHE_NAME = 'agrovetor-cache-v10'; // Incremented version for update
+const TILE_CACHE_NAME = 'agrovetor-tile-cache-v2'; // New cache for Mapbox tiles
 const MAX_TILES_IN_CACHE = 2000; // Max number of tiles to cache
 
 // Helper function to limit the size of the tile cache
@@ -79,9 +79,8 @@ self.addEventListener('fetch', event => {
 
   const url = new URL(event.request.url);
 
-  // Strategy for Google Maps satellite TILEs (Cache First with trimming)
-  // The path '/kh/v=' is specific to satellite imagery (Keyhole).
-  if (url.hostname.endsWith('.google.com') && url.pathname.includes('/kh/v=')) {
+  // Strategy for Mapbox tiles, fonts, and sprites (Cache First with trimming)
+  if (url.hostname.includes('mapbox.com')) {
     event.respondWith(
       caches.open(TILE_CACHE_NAME).then(cache => {
         return cache.match(event.request).then(response => {


### PR DESCRIPTION
This commit addresses a critical bug where the service worker was configured to cache Google Maps tiles while the application had been migrated to Mapbox, rendering the offline map feature non-functional.

Key changes:
- Corrected `service-worker.js` to cache Mapbox tiles instead of Google Maps tiles.
- Incremented the cache version to ensure the new service worker is activated.
- Refactored the `findTalhaoFromLocation` function in `app.js` to use Turf.js for spatial analysis, removing all dependencies on the Google Maps Geometry library.
- Removed obsolete Google Maps API references throughout the application to prevent conflicts and improve code quality.