### PR TITLE
fix: Force PWA update by incrementing service worker cache version

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
-const CACHE_NAME = 'agrovetor-cache-v10'; // Incremented version for update
-const TILE_CACHE_NAME = 'agrovetor-tile-cache-v2'; // New cache for Mapbox tiles
+const CACHE_NAME = 'agrovetor-cache-v11'; // Incremented version for update
+const TILE_CACHE_NAME = 'agrovetor-tile-cache-v3'; // Incremented tile cache
 const MAX_TILES_IN_CACHE = 2000; // Max number of tiles to cache
 
 // Helper function to limit the size of the tile cache


### PR DESCRIPTION
Incremented the cache version in `service-worker.js` from v10 to v11. This is a necessary step to ensure that Progressive Web Apps (PWAs) installed on user devices will download the latest version of the application files, including the critical fix for the offline synchronization bug.

This also finalizes the implementation of the persistent notification history feature.