### PR TITLE
Refatora carregamento de shapefile para usar Firebase Storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -855,8 +855,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         if (doc.exists()) {
                             const configData = doc.data();
                             App.state.companyLogo = configData.logoBase64 || null;
-                            if (configData.shapefileBase64) {
-                                App.mapModule.loadAndCacheShapesFromBase64(configData.shapefileBase64);
+                            if (configData.shapefileURL) {
+                                App.mapModule.loadAndCacheShapes(configData.shapefileURL);
                             }
                         } else {
                             App.state.companyLogo = null;
@@ -5289,41 +5289,6 @@ document.addEventListener('DOMContentLoaded', () => {
         },
 
         mapModule: {
-            _base64ToArrayBuffer(base64) {
-                const binary_string = window.atob(base64);
-                const len = binary_string.length;
-                const bytes = new Uint8Array(len);
-                for (let i = 0; i < len; i++) {
-                    bytes[i] = binary_string.charCodeAt(i);
-                }
-                return bytes.buffer;
-            },
-            async loadAndCacheShapesFromBase64(base64String) {
-                if (!base64String) {
-                    console.log("Nenhum shapefile em base64 encontrado na configuração para carregar.");
-                    return;
-                }
-                console.log("Iniciando o carregamento dos contornos do mapa a partir de base64...");
-                try {
-                    const buffer = this._base64ToArrayBuffer(base64String);
-
-                    // Cache the raw base64 string for offline use
-                    await OfflineDB.set('shapefile-cache', 'shapefile-base64', base64String);
-
-                    console.log("Processando e desenhando os talhões no mapa...");
-                    const geojson = await shp(buffer);
-
-                    App.state.geoJsonData = geojson;
-                    if (App.state.mapboxMap) {
-                        this.loadShapesOnMap();
-                    }
-                    console.log("Contornos do mapa carregados com sucesso a partir de base64.");
-                } catch(err) {
-                    console.error("Erro ao carregar shapefile a partir de base64:", err);
-                    App.ui.showAlert("Falha ao carregar os desenhos do mapa. Tentando usar o cache.", "warning");
-                    this.loadOfflineShapes();
-                }
-            },
             initMap() {
                 if (App.state.mapboxMap) return; // Evita reinicialização
                 if (typeof mapboxgl === 'undefined') {
@@ -5418,48 +5383,77 @@ document.addEventListener('DOMContentLoaded', () => {
                     return;
                 }
 
-                const MAX_SIZE_KB = 700;
-                if (file.size > MAX_SIZE_KB * 1024) {
-                    App.ui.showAlert(`O ficheiro é muito grande. O tamanho máximo é de ${MAX_SIZE_KB}KB.`, 'error');
-                    input.value = '';
+                const companyId = App.state.currentUser.companyId;
+                if (!companyId) {
+                    App.ui.showAlert("ID da empresa não encontrado. Não é possível fazer o upload.", "error");
                     return;
                 }
 
-                App.ui.setLoading(true, "A processar e carregar o shapefile...");
+                App.ui.setLoading(true, "A enviar o arquivo para o armazenamento...");
 
-                const reader = new FileReader();
-                reader.onload = async (event) => {
-                    const base64String = event.target.result.split(',')[1];
-                    try {
-                        await App.data.setDocument('config', App.state.currentUser.companyId, { shapefileBase64: base64String }, { merge: true });
-                        App.ui.showAlert('Shapefile carregado com sucesso!');
-                    } catch (error) {
-                        console.error("Erro ao carregar o shapefile para o Firestore:", error);
-                        App.ui.showAlert(`Erro ao carregar o shapefile: ${error.message}`, 'error');
-                    } finally {
-                        App.ui.setLoading(false);
-                        input.value = '';
+                const storageRef = ref(storage, `shapefiles/${companyId}/map.zip`);
+
+                try {
+                    const uploadResult = await uploadBytes(storageRef, file);
+                    App.ui.setLoading(true, "A obter o link de download...");
+
+                    const downloadURL = await getDownloadURL(uploadResult.ref);
+
+                    await App.data.setDocument('config', companyId, { shapefileURL: downloadURL }, { merge: true });
+
+                    App.ui.showAlert("Arquivo enviado com sucesso! O mapa será atualizado em breve.", "success");
+
+                } catch (error) {
+                    console.error("Erro no upload do shapefile:", error);
+                    let errorMessage = "Ocorreu um erro durante o upload.";
+                    if (error.code) {
+                        switch (error.code) {
+                            case 'storage/unauthorized':
+                                errorMessage = "Não tem permissão para enviar arquivos. Verifique as regras de segurança do Storage.";
+                                break;
+                            case 'storage/canceled':
+                                errorMessage = "O envio foi cancelado.";
+                                break;
+                            case 'storage/unknown':
+                                errorMessage = "Ocorreu um erro desconhecido no servidor.";
+                                break;
+                        }
                     }
-                };
-                reader.onerror = (error) => {
+                    App.ui.showAlert(errorMessage, "error");
+                } finally {
                     App.ui.setLoading(false);
-                    App.ui.showAlert('Erro ao ler o ficheiro.', 'error');
-                    console.error("Erro FileReader:", error);
-                };
-                reader.readAsDataURL(file);
+                    input.value = '';
+                }
+            },
+
+            async loadAndCacheShapes(url) {
+                if (!url) return;
+                console.log("Iniciando o carregamento dos contornos do mapa em segundo plano...");
+                try {
+                    const urlWithCacheBuster = `${url}?t=${new Date().getTime()}`;
+                    const response = await fetch(urlWithCacheBuster);
+                    if (!response.ok) throw new Error(`Não foi possível baixar o shapefile: ${response.statusText}`);
+                    const buffer = await response.arrayBuffer();
+
+                    await OfflineDB.set('shapefile-cache', 'shapefile-zip', buffer);
+
+                    console.log("Processando e desenhando os talhões no mapa...");
+                    const geojson = await shp(buffer);
+
+                    App.state.geoJsonData = geojson;
+                    if (App.state.mapboxMap) {
+                        this.loadShapesOnMap();
+                    }
+                    console.log("Contornos do mapa carregados com sucesso.");
+                } catch(err) {
+                    console.error("Erro ao carregar shapefile do Storage:", err);
+                    App.ui.showAlert("Falha ao carregar os desenhos do mapa. Tentando usar o cache.", "warning");
+                    this.loadOfflineShapes();
+                }
             },
 
             async loadOfflineShapes() {
-                let buffer;
-                // Prioritize the new base64 cache
-                const base64String = await OfflineDB.get('shapefile-cache', 'shapefile-base64');
-                if (base64String) {
-                    buffer = this._base64ToArrayBuffer(base64String);
-                } else {
-                    // Fallback to the old zip buffer for backward compatibility
-                    buffer = await OfflineDB.get('shapefile-cache', 'shapefile-zip');
-                }
-
+                const buffer = await OfflineDB.get('shapefile-cache', 'shapefile-zip');
                 if (buffer) {
                     App.ui.showAlert("A carregar mapa do cache offline.", "info");
                     try {


### PR DESCRIPTION
Esta alteração modifica a forma como os arquivos de shapefile (limites de talhões) são carregados no mapa, resolvendo o problema de limite de tamanho de arquivo.

A abordagem anterior, que salvava o arquivo como uma string Base64 no Firestore, foi substituída por uma solução mais robusta usando o Firebase Cloud Storage, que é o padrão para arquivos grandes.

Principais alterações:
- A função de upload de shapefile (`handleShapefileUpload`) agora envia o arquivo `.zip` diretamente para o Firebase Cloud Storage.
- Após o upload, a URL de download do arquivo é salva no documento de configuração da empresa no Firestore.
- O aplicativo utiliza essa URL para baixar, processar e exibir os shapes no mapa.
- A funcionalidade de cache offline foi mantida para garantir que o mapa funcione sem conexão com a internet após o primeiro carregamento.