### PR TITLE
Fix: Load company data for regular users to unlock modules

### DIFF
--- a/app.js
+++ b/app.js
@@ -849,6 +849,27 @@ document.addEventListener('DOMContentLoaded', () => {
                         App.state.unsubscribeListeners.push(unsubscribe);
                     });
 
+                    // **INÍCIO DA CORREÇÃO**
+                    // Adiciona um listener para o documento da própria empresa
+                    const companyDocRef = doc(db, 'companies', companyId);
+                    const unsubscribeCompany = onSnapshot(companyDocRef, (doc) => {
+                        if (doc.exists()) {
+                            // Atualiza o estado com os dados da empresa do utilizador
+                            App.state.companies = [{ id: doc.id, ...doc.data() }];
+                            // Re-renderiza o menu para aplicar as permissões do módulo
+                            App.ui.renderMenu();
+                        } else {
+                            // Se a empresa não for encontrada, é um estado inconsistente. Deslogar o utilizador.
+                            console.error(`A empresa com ID ${companyId} não foi encontrada para o utilizador ${App.state.currentUser.uid}. A deslogar.`);
+                            App.auth.logout();
+                            App.ui.showLoginMessage("A sua empresa não foi encontrada. Contacte o suporte.", "error");
+                        }
+                    }, (error) => {
+                        console.error(`Erro ao ouvir o documento da empresa ${companyId}: `, error);
+                    });
+                    App.state.unsubscribeListeners.push(unsubscribeCompany);
+                    // **FIM DA CORREÇÃO**
+
                     // Configurações específicas da empresa (logotipo, etc.)
                     const configDocRef = doc(db, 'config', companyId);
                     const unsubscribeConfig = onSnapshot(configDocRef, (doc) => {


### PR DESCRIPTION
The application was not fetching the logged-in user's company document, which contains the list of subscribed modules. This caused the UI to incorrectly hide all modules for regular users, as it appeared they had no permissions.

This change adds a Firestore listener to the `App.data.listenToAllData` function. The new listener fetches the user's company data, updates the application state, and re-renders the menu, ensuring that module access is correctly determined based on the company's subscriptions. This resolves the bug where users, particularly on mobile, could not access their permitted modules.