### PR TITLE
Fix: Carrega dados da empresa para usuários não-admins

### DIFF
--- a/index.html
+++ b/index.html
@@ -2178,6 +2178,15 @@
                     </div>
                 </div>
 
+                <div id="featureManagementCard" class="card" style="border-left-color: var(--color-ai); margin-top: 30px; display: none;">
+                    <h3><i class="fas fa-toggle-on"></i> Gestão de Funcionalidades</h3>
+                    <p style="font-size: 14px; color: var(--color-text-light); margin-top: -15px; margin-bottom: 20px;">Ative ou desative as novas funcionalidades que foram disponibilizadas para a sua empresa.</p>
+                    <div id="companyFeaturesGrid" class="permission-grid">
+                        <!-- As funcionalidades ativáveis serão geradas aqui pelo app.js -->
+                    </div>
+                    <button id="btnSaveChangesCompanyFeatures" class="save" style="max-width: 300px; margin-top: 25px; background: var(--color-ai);"><i class="fas fa-save"></i> Guardar Alterações nas Funcionalidades</button>
+                </div>
+
                 <div class="card" style="border-left-color: var(--color-info); margin-top: 30px;">
                     <h3><i class="fas fa-sync-alt"></i> Sincronização Global dos Planos de Colheita</h3>
                     <p>Importe relatórios do seu sistema principal para manter <strong>todos os planos de colheita</strong> sempre atualizados com a operação real.</p>
@@ -2414,6 +2423,14 @@
                     <label class="required" style="font-size: 15px; margin-bottom: 10px;">Módulos Subscritos:</label>
                     <div class="checkbox-group-grid" id="editCompanyModulesGrid">
                         <!-- Os módulos serão gerados aqui pelo app.js -->
+                    </div>
+                </div>
+
+                <div class="checkbox-group-container" style="margin-top: 20px;">
+                    <label style="font-size: 15px; margin-bottom: 10px;">Funcionalidades Disponíveis:</label>
+                     <p style="font-size: 12px; color: var(--color-text-light); margin-top: -8px; margin-bottom: 10px;">Selecione as novas funcionalidades que esta empresa poderá ativar no seu próprio painel de configurações.</p>
+                    <div class="checkbox-group-grid" id="editCompanyFeaturesGrid">
+                        <!-- As funcionalidades disponíveis serão geradas aqui pelo app.js -->
                     </div>
                 </div>
 


### PR DESCRIPTION
O problema original era que usuários em dispositivos móveis (e, na verdade, qualquer usuário que não fosse super-admin) não conseguiam ver os módulos da aplicação, que apareciam bloqueados.

A causa raiz era que a aplicação não carregava os dados da empresa do usuário logado, o que impedia a verificação dos `subscribedModules` (módulos subscritos). A função `App.data.listenToAllData` só carregava a lista completa de empresas para super-admins.

Esta correção resolve o problema da seguinte forma:

1.  **Carregamento de Dados da Empresa**: Modifica a função `App.data.listenToAllData` para adicionar um listener `onSnapshot` que busca o documento da empresa do usuário logado (se não for super-admin). Isso garante que `App.state.companies` seja populado com os dados necessários.

2.  **Renderização do Menu**: A função `App.ui.renderMenu()` é chamada logo após o carregamento dos dados da empresa, garantindo que a interface seja atualizada com as permissões corretas e os módulos sejam desbloqueados como esperado.