### PR TITLE
fix: Handle Firestore query limit and orderBy reference error

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // FIREBASE: Importe os módulos necessários do Firebase SDK
 import { initializeApp } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-app.js";
-import { getFirestore, collection, onSnapshot, doc, getDoc, addDoc, setDoc, updateDoc, deleteDoc, writeBatch, serverTimestamp, query, where, getDocs, enableIndexedDbPersistence, Timestamp } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-firestore.js";
+import { getFirestore, collection, onSnapshot, doc, getDoc, addDoc, setDoc, updateDoc, deleteDoc, writeBatch, serverTimestamp, query, where, getDocs, enableIndexedDbPersistence, Timestamp, orderBy } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-firestore.js";
 import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut, onAuthStateChanged, updatePassword, sendPasswordResetEmail, EmailAuthProvider, reauthenticateWithCredential, setPersistence, browserSessionPersistence } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-auth.js";
 import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/9.15.0/firebase-storage.js";
 // Importa a biblioteca para facilitar o uso do IndexedDB (cache offline)


### PR DESCRIPTION
This commit addresses two distinct bugs:

1.  The `notifyAdminsOfNewFeatures` function would fail if more than 10 features were enabled simultaneously due to the Firestore `array-contains-any` operator's 10-element limit. The function has been refactored to chunk the list of features into groups of 10, execute a separate query for each chunk, and consolidate the results.

2.  The `renderSyncHistory` function was throwing a `ReferenceError: orderBy is not defined` because the `orderBy` function was not imported from the Firestore SDK. The import statement has been updated to include it, resolving the error.