### PR TITLE
fix: Implement notification details and login security

### DIFF
--- a/index.html
+++ b/index.html
@@ -1463,7 +1463,7 @@
                     <label for="loginUser">Email</label>
                 </div>
                 <div class="input-field">
-                    <input id="loginPass" type="password" placeholder=" " required />
+                    <input id="loginPass" type="password" placeholder=" " required autocomplete="new-password" />
                     <label for="loginPass">Senha</label>
                 </div>
                 <button id="btnLogin" aria-label="Botão de login"><i class="fas fa-sign-in-alt"></i> LOGIN</button>


### PR DESCRIPTION
This commit resolves two issues reported by the user.

First, it enables clicking on synchronization notifications to view details. The Firestore document ID of the sync log is now stored with the notification. An event listener has been added to the notification list that uses this ID to call `App.ui.renderSyncHistoryDetails` and display the appropriate modal. The related functions have been refactored into the `App.ui` object for better code structure.

Second, to improve login security, the password field in `index.html` has been updated with `autocomplete="new-password"`. This attribute instructs browsers not to save or autofill the user's password, mitigating a potential security risk.