### PR TITLE
fix: Ajusta cálculo e UI do módulo de amostragem de cigarrinha

### DIFF
--- a/app.js
+++ b/app.js
@@ -2278,19 +2278,17 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
 
                 const divisor = parseInt(App.state.companyConfig?.cigarrinhaCalcMethod || '5', 10);
-                let somaDasMedias = 0;
+                let somaTotalDeFases = 0;
 
                 amostras.forEach(card => {
-                    let somaFasesDaAmostra = 0;
                     card.querySelectorAll('.amostra-input').forEach(input => {
-                        somaFasesDaAmostra += parseInt(input.value) || 0;
+                        somaTotalDeFases += parseInt(input.value) || 0;
                     });
-                    somaDasMedias += (somaFasesDaAmostra / divisor);
                 });
 
-                const mediaFinal = somaDasMedias / amostras.length;
+                const resultadoFinal = somaTotalDeFases / divisor;
 
-                resultadoEl.textContent = `Resultado (Média das Amostras): ${mediaFinal.toFixed(2).replace('.', ',')}`;
+                resultadoEl.textContent = `Resultado: ${resultadoFinal.toFixed(2).replace('.', ',')}`;
             },
 
             showConfirmationModal(message, onConfirm, inputsConfig = false) {
@@ -2534,7 +2532,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         ${[1, 2, 3, 4, 5].map(i => `
                             <div class="form-col">
                                 <label for="fase${i}-amostra-${amostraId}">Fase ${i}:</label>
-                                <input type="number" id="fase${i}-amostra-${amostraId}" class="amostra-input" min="0" value="0">
+                                <input type="number" id="fase${i}-amostra-${amostraId}" class="amostra-input" min="0" placeholder="0">
                             </div>
                         `).join('')}
                     </div>


### PR DESCRIPTION
Este commit aplica os ajustes solicitados pelo usuário para finalizar o módulo de amostragem de cigarrinha:

1.  **Lógica de Cálculo:** A fórmula de resultado foi alterada. Agora, calcula-se a soma total de todas as fases de todas as sub-amostras e divide-se o resultado pelo divisor configurado (5 ou 10). Isso se aplica tanto à exibição em tempo real na tela quanto ao valor salvo no Firestore.

2.  **Interface do Usuário (UI):** Os campos de input para as fases nas sub-amostras agora começam vazios com o placeholder "0", em vez de preenchidos com o valor "0", para manter a consistência visual com outros módulos da aplicação.