### PR TITLE
Fix: Correct Cigarrinha calculation and raw data display in report

### DIFF
--- a/app.js
+++ b/app.js
@@ -4675,6 +4675,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         const f3 = parseInt(els.fase3.value) || 0;
                         const f4 = parseInt(els.fase4.value) || 0;
                         const f5 = parseInt(els.fase5.value) || 0;
+                        const divisor = parseInt(App.state.companyConfig?.cigarrinhaCalcMethod || '5', 10);
                         return {
                             data: els.data.value,
                             codigo: farm.code,
@@ -4683,7 +4684,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             variedade: talhao.variedade || '',
                             fase1: f1, fase2: f2, fase3: f3, fase4: f4, fase5: f5,
                             adulto: els.adulto.checked,
-                            resultado: ((f1 + f2 + f3 + f4 + f5) / 5) / 10,
+                            resultado: (f1 + f2 + f3 + f4 + f5) / divisor,
                             usuario: App.state.currentUser.username,
                             companyId: App.state.currentUser.companyId
                         };


### PR DESCRIPTION
This commit addresses two issues related to the 'cigarrinha' feature:

1.  **Data-saving Calculation:** The `saveCigarrinha` function in `app.js` has been modified to ensure the 'resultado' value is calculated using the configurable divisor from the company's settings. This aligns the data saved to the database with the calculation displayed in the user interface.

2.  **Report Display:** The PDF and CSV reports for 'cigarrinha' in `backend/server.js` have been updated to display the raw 'resultado' value from the database, removing any additional formatting or calculations.