### PR TITLE
Fix report caching issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -7564,7 +7564,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
 
                     const params = new URLSearchParams(cleanFilters);
-                    const apiUrl = `${App.config.backendUrl}/reports/${endpoint}?${params.toString()}`;
+                    const apiUrl = `${App.config.backendUrl}/reports/${endpoint}?${params.toString()}&_cacheBust=${Date.now()}`;
 
                     App.ui.setLoading(true, "A gerar relatório no servidor...");
 


### PR DESCRIPTION
This change adds a cache-busting parameter to the report generation URL to prevent the browser from serving cached report data.