### PR TITLE
This commit introduces two major features: a read-only "Support Mode"…

### DIFF
--- a/app.js
+++ b/app.js
@@ -984,15 +984,31 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
             },
             async addDocument(collectionName, data) {
+                if (App.state.isImpersonating) {
+                    App.ui.showAlert("Operações de escrita estão desativadas no modo de suporte.", "warning");
+                    throw new Error("MODO DE SUPORTE ATIVO");
+                }
                 return await addDoc(collection(db, collectionName), { ...data, createdAt: serverTimestamp() });
             },
             async setDocument(collectionName, docId, data) {
+                if (App.state.isImpersonating) {
+                    App.ui.showAlert("Operações de escrita estão desativadas no modo de suporte.", "warning");
+                    throw new Error("MODO DE SUPORTE ATIVO");
+                }
                 return await setDoc(doc(db, collectionName, docId), data, { merge: true });
             },
             async updateDocument(collectionName, docId, data) {
+                if (App.state.isImpersonating) {
+                    App.ui.showAlert("Operações de escrita estão desativadas no modo de suporte.", "warning");
+                    throw new Error("MODO DE SUPORTE ATIVO");
+                }
                 return await updateDoc(doc(db, collectionName, docId), data);
             },
             async deleteDocument(collectionName, docId) {
+                if (App.state.isImpersonating) {
+                    App.ui.showAlert("Operações de escrita estão desativadas no modo de suporte.", "warning");
+                    throw new Error("MODO DE SUPORTE ATIVO");
+                }
                 return await deleteDoc(doc(db, collectionName, docId));
             },
             async getUserData(uid, options = {}) {
@@ -5856,6 +5872,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Store original user
                 App.state.originalUser = { ...App.state.currentUser };
                 App.state.isImpersonating = true;
+                document.body.classList.add('support-mode');
+
 
                 // Create a fake admin user for the target company
                 const adminPermissions = App.config.roles['admin'];
@@ -5882,6 +5900,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 App.state.currentUser = { ...App.state.originalUser };
                 App.state.originalUser = null;
                 App.state.isImpersonating = false;
+                document.body.classList.remove('support-mode');
 
                 // Re-initialize the app view
                 App.data.listenToAllData(); // This will go back to super-admin view
@@ -7834,14 +7853,40 @@ document.addEventListener('DOMContentLoaded', () => {
         pwa: {
             registerServiceWorker() {
                 if ('serviceWorker' in navigator) {
-                    window.addEventListener('load', () => {
-                        navigator.serviceWorker.register('./service-worker.js')
-                            .then(registration => {
-                                console.log('ServiceWorker registration successful with scope: ', registration.scope);
-                            })
-                            .catch(error => {
-                                console.log('ServiceWorker registration failed: ', error);
-                            });
+                    navigator.serviceWorker.register('./service-worker.js').then(registration => {
+                        console.log('ServiceWorker registration successful');
+
+                        registration.onupdatefound = () => {
+                            const installingWorker = registration.installing;
+                            if (installingWorker) {
+                                installingWorker.onstatechange = () => {
+                                    if (installingWorker.state === 'installed') {
+                                        if (navigator.serviceWorker.controller) {
+                                            // Nova versão disponível
+                                            console.log('New content is available and will be used when all tabs for this scope are closed.');
+                                            const updateBanner = document.getElementById('update-notification');
+                                            const updateBtn = document.getElementById('update-now-btn');
+                                            if (updateBanner) updateBanner.style.display = 'block';
+                                            if (updateBtn) {
+                                                updateBtn.onclick = () => {
+                                                    registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+                                                };
+                                            }
+                                        }
+                                    }
+                                };
+                            }
+                        };
+
+                        let refreshing;
+                        navigator.serviceWorker.addEventListener('controllerchange', () => {
+                            if (refreshing) return;
+                            window.location.reload();
+                            refreshing = true;
+                        });
+
+                    }).catch(error => {
+                        console.log('ServiceWorker registration failed: ', error);
                     });
 
                     window.addEventListener('beforeinstallprompt', (e) => {

--- a/index.html
+++ b/index.html
@@ -1532,6 +1532,24 @@
               width: 100%;
           }
       }
+
+      /* Estilos para o Modo de Suporte (Super Admin) */
+      body.support-mode button,
+      body.support-mode input,
+      body.support-mode select,
+      body.support-mode textarea,
+      body.support-mode .upload-area {
+          pointer-events: none !important;
+          opacity: 0.6 !important;
+          cursor: not-allowed !important;
+      }
+
+      body.support-mode .btn-excluir,
+      body.support-mode .save {
+          background: #ccc !important;
+          box-shadow: none !important;
+          transform: none !important;
+      }
     </style>
 </head>
 <body>
@@ -1542,6 +1560,11 @@
 
     <div id="alertContainer"></div>
     <div id="notification-container"></div>
+
+    <div id="update-notification" style="display: none; background-color: var(--color-info); color: white; padding: 15px; text-align: center; position: fixed; top: 70px; width: 100%; z-index: 1051; box-shadow: var(--shadow-md);">
+        <span>Uma nova versão do sistema está disponível.</span>
+        <button id="update-now-btn" style="background: white; color: var(--color-info); border: none; padding: 8px 16px; border-radius: 5px; margin-left: 15px; cursor: pointer; font-weight: bold;">Atualizar Agora</button>
+    </div>
 
     <div id="loading-overlay">
         <div class="spinner"></div>

--- a/service-worker.js
+++ b/service-worker.js
@@ -39,9 +39,8 @@ const urlsToCache = [
   'https://www.gstatic.com/firebasejs/9.15.0/firebase-storage.js'
 ];
 
-// Install event: force the new service worker to become active
+// Install event: cache assets, but wait for activation
 self.addEventListener('install', event => {
-  self.skipWaiting(); 
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then(cache => {
@@ -49,6 +48,14 @@ self.addEventListener('install', event => {
         return cache.addAll(urlsToCache);
       })
   );
+});
+
+// Listen for a message from the client to activate the new service worker
+self.addEventListener('message', (event) => {
+    if (event.data && event.data.type === 'SKIP_WAITING') {
+        console.log('SKIP_WAITING message received. Activating new service worker.');
+        self.skipWaiting();
+    }
 });
 
 // Activate event: clean up old caches and take control


### PR DESCRIPTION
… for super-admins and a user-friendly PWA update notification system.

The Super-Admin Support Mode allows administrators to impersonate other companies to provide support without the risk of accidentally modifying data. This is achieved by:
- Blocking all database write operations (add, set, update, delete) in the frontend when `isImpersonating` is true.
- Adding a `support-mode` class to the body during impersonation, which is used by CSS to visually disable all interactive elements like buttons and inputs, making the UI read-only.

The PWA Update Notification system improves the update process by:
- Modifying the service worker to wait for a `SKIP_WAITING` message instead of activating immediately.
- Detecting when a new version is available and displaying a notification banner to the user.
- Allowing the user to trigger the update by clicking an "Update Now" button, which sends the required message to the service worker and reloads the page.