### PR TITLE
feat: Add Python script for CHB data import

### DIFF
--- a/backend/import_chb_data.py
+++ b/backend/import_chb_data.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+
+"""
+Script para importar dados históricos de colheita de planilhas Excel (padrão CHB) para o Firestore.
+
+Este script lê um arquivo Excel contendo dados de fazendas, toneladas e ATR,
+processa os dados de cada linha e os insere na coleção 'historicalHarvests' do Firestore.
+
+Uso:
+  python import_chb_data.py <caminho_para_o_arquivo.xlsx> <companyId>
+
+Argumentos:
+  <caminho_para_o_arquivo.xlsx>  O caminho para o arquivo Excel a ser importado.
+  <companyId>                      O ID da empresa a ser associado aos registros.
+
+Requisitos:
+  - pandas
+  - firebase-admin
+  - openpyxl
+"""
+
+import os
+import sys
+import pandas as pd
+import firebase_admin
+from firebase_admin import credentials, firestore
+from datetime import datetime
+
+def initialize_firestore():
+    """
+    Inicializa a conexão com o Firestore usando as credenciais de uma variável de ambiente.
+
+    A variável de ambiente 'FIREBASE_APPLICATION_CREDENTIALS' deve ser definida com o
+    caminho para o arquivo JSON de credenciais do Firebase.
+    """
+    cred_path = os.getenv('FIREBASE_APPLICATION_CREDENTIALS')
+    if not cred_path:
+        print("Erro: A variável de ambiente 'FIREBASE_APPLICATION_CREDENTIALS' não está definida.")
+        print("Por favor, configure-a com o caminho para o seu arquivo de credenciais JSON do Firebase.")
+        sys.exit(1)
+
+    try:
+        # Verifica se o app Firebase já foi inicializado para evitar erros
+        if not firebase_admin._apps:
+            cred = credentials.Certificate(cred_path)
+            firebase_admin.initialize_app(cred)
+
+        print("Conexão com o Firestore inicializada com sucesso.")
+        return firestore.client()
+    except Exception as e:
+        print(f"Erro ao inicializar o Firestore: {e}")
+        sys.exit(1)
+
+def process_excel_file(file_path, company_id):
+    """
+    Lê uma planilha Excel e a transforma em uma lista de registros para o Firestore.
+
+    Args:
+        file_path (str): O caminho para o arquivo Excel.
+        company_id (str): O ID da empresa a ser associado aos registros.
+
+    Returns:
+        list: Uma lista de dicionários, onde cada dicionário representa um registro válido.
+    """
+    try:
+        df = pd.read_excel(file_path)
+        print(f"Arquivo '{file_path}' lido com sucesso. Encontradas {len(df)} linhas.")
+    except FileNotFoundError:
+        print(f"Erro: O arquivo '{file_path}' não foi encontrado.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Erro ao ler o arquivo Excel: {e}")
+        sys.exit(1)
+
+    # Normaliza os nomes das colunas (minúsculas, sem espaços)
+    df.columns = [str(col).strip().lower() for col in df.columns]
+
+    records_to_save = []
+    required_columns = ['codigofazenda', 'toneladas', 'atr']
+
+    # Valida se as colunas obrigatórias existem no DataFrame
+    for col in required_columns:
+        if col not in df.columns:
+            print(f"Erro: A coluna obrigatória '{col}' não foi encontrada no arquivo Excel.")
+            print(f"Colunas encontradas: {list(df.columns)}")
+            sys.exit(1)
+
+    for index, row in df.iterrows():
+        try:
+            # Extrai e converte os dados da linha
+            codigo_fazenda = str(row['codigofazenda']).strip()
+
+            # Converte para float, tratando vírgulas e valores não numéricos
+            toneladas_str = str(row['toneladas']).replace(',', '.')
+            toneladas = float(toneladas_str) if toneladas_str else 0.0
+
+            atr_str = str(row['atr']).replace(',', '.')
+            atr_realizado = float(atr_str) if atr_str else 0.0
+
+            # Validação: só importa registros com dados essenciais e valores positivos
+            if codigo_fazenda and toneladas > 0 and atr_realizado > 0:
+                record = {
+                    'companyId': company_id,
+                    'codigoFazenda': codigo_fazenda,
+                    'toneladas': toneladas,
+                    'atrRealizado': atr_realizado,
+                    'importedAt': datetime.now() # O SDK do Python converte para Timestamp do Firestore
+                }
+                records_to_save.append(record)
+            else:
+                print(f"Aviso: Linha {index + 2} ignorada por conter dados inválidos ou zerados.")
+
+        except (ValueError, TypeError) as e:
+            print(f"Aviso: Erro ao processar a linha {index + 2}. Dados podem estar em formato incorreto. Erro: {e}")
+            continue
+
+    return records_to_save
+
+def save_to_firestore(db, records):
+    """
+    Salva uma lista de registros na coleção 'historicalHarvests' do Firestore em lotes.
+
+    Args:
+        db: A instância do cliente Firestore.
+        records (list): A lista de registros a serem salvos.
+    """
+    if not records:
+        print("Nenhum registro válido para salvar.")
+        return
+
+    collection_ref = db.collection('historicalHarvests')
+    batch = db.batch()
+    batch_size = 400  # O Firestore suporta até 500 operações por lote
+    total_saved = 0
+
+    for i, record in enumerate(records):
+        doc_ref = collection_ref.document()
+        batch.set(doc_ref, record)
+
+        # Commita o lote a cada `batch_size` registros ou no último registro
+        if (i + 1) % batch_size == 0 or (i + 1) == len(records):
+            try:
+                batch.commit()
+                # O número de escritas é `len(batch._writes)` antes do commit
+                print(f"Lote de {i - total_saved + 1} registros salvo com sucesso.")
+                total_saved += (i - total_saved + 1)
+                batch = db.batch()  # Reinicia o lote para o próximo conjunto
+            except Exception as e:
+                print(f"Erro crítico ao salvar lote no Firestore: {e}")
+                # Decide se quer parar ou continuar em caso de erro
+                sys.exit(1)
+
+    print(f"\nImportação concluída. Total de {total_saved} registros salvos na coleção 'historicalHarvests'.")
+
+def main():
+    """
+    Função principal para orquestrar o processo de importação.
+    """
+    if len(sys.argv) != 3:
+        print("Uso: python import_chb_data.py <caminho_para_o_arquivo.xlsx> <companyId>")
+        sys.exit(1)
+
+    file_path = sys.argv[1]
+    company_id = sys.argv[2]
+
+    print("--- Iniciando Script de Importação de Histórico de Colheita ---")
+
+    db = initialize_firestore()
+    records = process_excel_file(file_path, company_id)
+
+    save_to_firestore(db, records)
+
+    print("--- Script de Importação Concluído ---")
+
+if __name__ == '__main__':
+    main()

--- a/backend/instructions.md
+++ b/backend/instructions.md
@@ -1,0 +1,99 @@
+# Instruções para Importação de Dados do CHB para o Firestore
+
+Este documento fornece um guia passo a passo para usar o script `import_chb_data.py` para carregar dados de colheita históricos de uma planilha Excel para o banco de dados Firestore da sua aplicação.
+
+## 1. Pré-requisitos
+
+Antes de começar, certifique-se de que você tem o seguinte:
+
+- **Python 3.x** instalado em seu computador. Você pode baixá-lo em [python.org](https://www.python.org/downloads/).
+- **pip**, o gerenciador de pacotes do Python, que geralmente já vem instalado com o Python.
+- Um arquivo de planilha **Excel (.xlsx)** exportado do sistema CHB.
+- O **ID da Empresa (`companyId`)** para a qual os dados serão importados.
+
+## 2. Instalação das Dependências
+
+O script requer algumas bibliotecas Python para funcionar. Abra o seu terminal (Prompt de Comando, PowerShell ou Terminal) e instale-as com o seguinte comando:
+
+```bash
+pip install pandas firebase-admin openpyxl
+```
+
+## 3. Configuração das Credenciais do Firebase
+
+Para que o script possa se conectar ao seu banco de dados Firestore, ele precisa de credenciais de segurança.
+
+### a. Obtenha o Arquivo de Credenciais
+
+1.  Acesse o **Console do Firebase** do seu projeto: [https://console.firebase.google.com/](https://console.firebase.google.com/)
+2.  Clique no ícone de engrenagem (Configurações do projeto) ao lado de "Visão geral do projeto" e selecione **"Configurações do projeto"**.
+3.  Vá para a aba **"Contas de serviço"**.
+4.  Clique no botão **"Gerar nova chave privada"**.
+5.  Um arquivo JSON será baixado para o seu computador. **Guarde este arquivo em um local seguro**, pois ele concede acesso total ao seu projeto Firebase.
+
+### b. Configure a Variável de Ambiente
+
+O script encontra as credenciais através de uma variável de ambiente. Você precisa configurar essa variável para apontar para o arquivo JSON que você acabou de baixar.
+
+**No Windows (usando o Prompt de Comando):**
+
+Substitua `"C:\caminho\para\seu\arquivo.json"` pelo caminho completo do seu arquivo de credenciais.
+
+```bash
+setx FIREBASE_APPLICATION_CREDENTIALS "C:\caminho\para\seu\arquivo.json"
+```
+
+**Importante:** Após executar este comando, você precisará **fechar e reabrir o terminal** para que a alteração tenha efeito.
+
+**No macOS ou Linux (usando o Terminal):**
+
+Substitua `"/caminho/para/seu/arquivo.json"` pelo caminho completo do seu arquivo de credenciais.
+
+```bash
+export FIREBASE_APPLICATION_CREDENTIALS="/caminho/para/seu/arquivo.json"
+```
+
+**Nota:** O comando `export` define a variável apenas para a sessão atual do terminal. Para torná-la permanente, adicione a linha acima ao seu arquivo de perfil do shell (como `~/.bashrc`, `~/.zshrc` ou `~/.profile`) e reinicie o terminal.
+
+## 4. Preparação do Arquivo Excel
+
+O script espera que sua planilha Excel tenha colunas específicas.
+
+-   **Nomes das Colunas:** O arquivo deve conter pelo menos as três colunas a seguir: `codigofazenda`, `toneladas` e `atr`. Os nomes não diferenciam maiúsculas de minúsculas e podem ter espaços (ex: "Codigo Fazenda" funciona).
+-   **Formato dos Dados:**
+    -   `codigofazenda`: O código que identifica a fazenda.
+    -   `toneladas`: O valor numérico das toneladas (pode usar vírgula ou ponto como separador decimal).
+    -   `atr`: O valor do ATR (também pode usar vírgula ou ponto).
+
+## 5. Executando o Script
+
+Com tudo configurado, você pode executar a importação.
+
+1.  Navegue até o diretório raiz do projeto no seu terminal.
+2.  Execute o script usando o seguinte formato de comando:
+
+    ```bash
+    python backend/import_chb_data.py <caminho_para_o_arquivo.xlsx> <companyId>
+    ```
+
+### Exemplo Prático:
+
+Suponha que seu arquivo Excel se chama `relatorio_chb.xlsx` e está na sua pasta de Downloads, e seu `companyId` é `agro-tech-123`.
+
+**No Windows:**
+
+```bash
+python backend/import_chb_data.py "C:\Users\SeuUsuario\Downloads\relatorio_chb.xlsx" "agro-tech-123"
+```
+
+**No macOS ou Linux:**
+
+```bash
+python backend/import_chb_data.py "/Users/SeuUsuario/Downloads/relatorio_chb.xlsx" "agro-tech-123"
+```
+
+O script exibirá o progresso no terminal, informando quantos registros foram lidos e salvos.
+
+## 6. Verificação
+
+Após a conclusão do script, você pode verificar se os dados foram importados corretamente acessando o **Firestore Database** no seu Console do Firebase e procurando pela coleção `historicalHarvests`. Lá, você encontrará os novos documentos criados pelo script.


### PR DESCRIPTION
This commit introduces a new Python script, `import_chb_data.py`, designed to facilitate the import of historical harvest data from Excel files into the Firestore database. This script addresses the user's need to automate data loading from an external "CHB" system where only Excel exports are available.

The script includes:
- Reading of .xlsx files using pandas.
- Data transformation and validation to match the `historicalHarvests` collection schema.
- Secure connection to Firestore using service account credentials via an environment variable.
- Batch writing to Firestore for efficient data loading.

Additionally, a detailed `instructions.md` file is included in the `backend/` directory to guide the user through setup, dependency installation, and script execution.